### PR TITLE
substitutionGroup fails: Unexpected <gml:ElectricLine>, expected: <gml:AbstractFeature>

### DIFF
--- a/__data__/gml_FeatureCollection.xsd
+++ b/__data__/gml_FeatureCollection.xsd
@@ -40,4 +40,18 @@
   </xs:complexType>
 
   <xs:element name="FeatureCollection" type="gml:FeatureCollectionType"/>
+
+  <!-- concrete feature with substitutionGroup -->
+  <xs:element name="ElectricLine" substitutionGroup="gml:AbstractFeature">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="gml:AbstractFeatureType">
+          <xs:sequence>
+            <xs:element name="GLOBALID" type="xs:string"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/__tests__/XMLValidatior.js
+++ b/__tests__/XMLValidatior.js
@@ -555,5 +555,24 @@ describe ('sequence', () => {
 
 	})
 
+})
+
+describe ('substitutionGroup', () => {
+
+	const xs = new XMLSchemata (Path.join (__dirname, '..', '__data__', 'gml_FeatureCollection.xsd'))
+
+	test ('concrete element accepted where abstract expected', () => {
+
+		new XMLParser ({xs}).process ([
+			`<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml/3.2">`,
+			`<gml:featureMember>`,
+			`<gml:ElectricLine>`,
+			`<gml:GLOBALID>test</gml:GLOBALID>`,
+			`</gml:ElectricLine>`,
+			`</gml:featureMember>`,
+			`</gml:FeatureCollection>`,
+		].join (''))
+
+	})
 
 })

--- a/__tests__/XMLValidatior.js
+++ b/__tests__/XMLValidatior.js
@@ -575,4 +575,30 @@ describe ('substitutionGroup', () => {
 
 	})
 
+	test ('element without substitutionGroup rejected', () => {
+
+		expect (() => new XMLParser ({xs}).process ([
+			`<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml/3.2">`,
+			`<gml:featureMember>`,
+			`<gml:FeatureCollection>`, // exists in schema but has no substitutionGroup
+			`</gml:FeatureCollection>`,
+			`</gml:featureMember>`,
+			`</gml:FeatureCollection>`,
+		].join (''))).toThrow ('Unexpected')
+
+	})
+
+	test ('unknown element rejected', () => {
+
+		expect (() => new XMLParser ({xs}).process ([
+			`<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml/3.2">`,
+			`<gml:featureMember>`,
+			`<gml:NoSuchElement>`,
+			`</gml:NoSuchElement>`,
+			`</gml:featureMember>`,
+			`</gml:FeatureCollection>`,
+		].join (''))).toThrow ('Unexpected')
+
+	})
+
 })

--- a/lib/XMLSchema.js
+++ b/lib/XMLSchema.js
@@ -51,6 +51,7 @@ const XMLSchema = class extends Map {
 			case 'group':
 				splitNs ('ref')
 				splitNs ('type')
+				splitNs ('substitutionGroup')
 				break
 	
 			case 'extension':

--- a/lib/validation/MatchElement.js
+++ b/lib/validation/MatchElement.js
@@ -6,11 +6,22 @@ class MatchElement extends Match {
 
         const {node: {attributes: {name}, targetNamespace}} = this.occurable
 
-        if (localName !== name || namespaceURI != targetNamespace) return null
+        if (localName === name && namespaceURI == targetNamespace) {
+
+            this.occured ++
+
+            return this.occurable.node
+
+        }
+
+        const el = this.occurable.xs?.getSchema (namespaceURI)?.get (localName)
+        const sg = el?.attributes?.substitutionGroup
+
+        if (!sg || sg [0] !== name || sg [1] !== targetNamespace) return null
 
         this.occured ++
 
-        return this.occurable.node
+        return el
 
     }
 


### PR DESCRIPTION
need to overcome `Unexpected <gml:ElectricLine>, expected: <gml:AbstractFeature>`

https://www.w3.org/TR/xmlschema11-1/#Element_Declaration_details `2.2.2.2 Element Substitution Group` states
```
a reference to the head validates not just the head itself,
but elements corresponding to any other member of the substitution group as well
```