### PR TITLE
FIX Unknown attribute: "gml:id" 

### DIFF
--- a/__data__/gml_id.xsd
+++ b/__data__/gml_id.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:gml="http://www.opengis.net/gml/3.2"
+           targetNamespace="http://www.opengis.net/gml/3.2"
+           elementFormDefault="qualified">
+
+  <xs:attribute name="id" type="xs:ID"/>
+
+  <xs:element name="FunctionalZone">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="GLOBALID" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute ref="gml:id"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/__tests__/XMLValidatior.js
+++ b/__tests__/XMLValidatior.js
@@ -572,4 +572,15 @@ describe ('gml:id attribute ref', () => {
 
 	})
 
+	test ('bare id rejected (namespace required)', () => {
+
+		expect (() => new XMLParser ({xs}).process ([
+			`<gml:FunctionalZone xmlns:gml="http://www.opengis.net/gml/3.2"`,
+			` id="FunctionalZone.0">`,
+			`<gml:GLOBALID>8b2457c9-85c4-466a-a14b-b20856527718</gml:GLOBALID>`,
+			`</gml:FunctionalZone>`,
+		].join (''))).toThrow ('Unknown attribute')
+
+	})
+
 })

--- a/__tests__/XMLValidatior.js
+++ b/__tests__/XMLValidatior.js
@@ -583,4 +583,16 @@ describe ('gml:id attribute ref', () => {
 
 	})
 
+	test ('wrong namespace rejected', () => {
+
+		expect (() => new XMLParser ({xs}).process ([
+			`<gml:FunctionalZone xmlns:gml="http://www.opengis.net/gml/3.2"`,
+			` xmlns:other="http://other.ns"`,
+			` other:id="FunctionalZone.0">`,
+			`<gml:GLOBALID>8b2457c9-85c4-466a-a14b-b20856527718</gml:GLOBALID>`,
+			`</gml:FunctionalZone>`,
+		].join (''))).toThrow ('Unknown attribute')
+
+	})
+
 })

--- a/__tests__/XMLValidatior.js
+++ b/__tests__/XMLValidatior.js
@@ -555,5 +555,21 @@ describe ('sequence', () => {
 
 	})
 
+})
+
+describe ('gml:id attribute ref', () => {
+
+	const xs = new XMLSchemata (Path.join (__dirname, '..', '__data__', 'gml_id.xsd'))
+
+	test ('gml:id accepted on FunctionalZone', () => {
+
+		new XMLParser ({xs}).process ([
+			`<gml:FunctionalZone xmlns:gml="http://www.opengis.net/gml/3.2"`,
+			` gml:id="FunctionalZone.0">`,
+			`<gml:GLOBALID>8b2457c9-85c4-466a-a14b-b20856527718</gml:GLOBALID>`,
+			`</gml:FunctionalZone>`,
+		].join (''))
+
+	})
 
 })

--- a/lib/validation/XMLValidationState.js
+++ b/lib/validation/XMLValidationState.js
@@ -114,21 +114,43 @@ class XMLValidationState {
 
 	}
 
+	resolveAttribute (name, attributesMap) {
+
+		const {attributes} = this.anyType
+
+		if (attributes.has (name)) return attributes.get (name)
+
+		const localName = attributesMap.getLocalName (name); if (localName === name) return null
+
+		const def = attributes.get (localName); if (!def) return null
+
+		if (def.targetNamespace !== attributesMap.getNamespaceURI (name)) return null
+
+		return def
+
+	}
+
 	validateAttributes (attributesMap) {
 
 		const {attributes, isAnyAttributeAllowed} = this.anyType
 
+		const matched = new Set ()
+
 		for (const [name, value] of attributesMap) {
 
-			if (!attributes.has (name)) {
+			const def = this.resolveAttribute (name, attributesMap)
+
+			if (!def) {
 
 				if (isAnyAttributeAllowed) continue
 
 				throw Error (`Unknown attribute: "${name}"`)
 
 			}
-			
-			const def = attributes.get (name), {attributes: {fixed, type}} = def
+
+			matched.add (def)
+
+			const {attributes: {fixed, type}} = def
 
 			if (typeof fixed === 'string' && value !== fixed) throw Error (`The attribute "${name}" must have the value "${fixed}", not "${value}"`)
 
@@ -160,7 +182,7 @@ class XMLValidationState {
 
 		}
 
-		for (const [name, def] of attributes) if (!attributesMap.has (name)) {
+		for (const [name, def] of attributes) if (!matched.has (def)) {
 
 			if (def.attributes.use === 'required') throw Error (`Missing required attribute: "${name}"`)
 

--- a/lib/validation/XMLValidationState.js
+++ b/lib/validation/XMLValidationState.js
@@ -118,7 +118,13 @@ class XMLValidationState {
 
 		const {attributes} = this.anyType
 
-		if (attributes.has (name)) return attributes.get (name)
+		if (attributes.has (name)) {
+
+			const def = attributes.get (name)
+
+			if (!def.targetNamespace || def.targetNamespace === attributesMap.getNamespaceURI (name)) return def
+
+		}
 
 		const localName = attributesMap.getLocalName (name); if (localName === name) return null
 


### PR DESCRIPTION
need to overcome Unknown attribute: "gml:id"

we have global attribute declaration like `<attribute ref="gml:id"/>`

 https://www.w3.org/TR/xmlschema11-1/#declare-attribute §3.2 Attribute Declarations states

```
global attribute declarations are always in the target namespace
and must always be qualified in instance documents.
```
 
when `<attribute ref="gml:id"/>` references a global declaration,
  the attribute in XML must be namespace-qualified (gml:id, not id).
 not reconginzed